### PR TITLE
Specify path to WordPress when generating config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,7 +47,7 @@ module.exports = function(grunt) {
             wpconfig: {
                 command: [
                     // Set up wp-config
-                    "wp core config --dbname="+ wp_db_name +" --dbuser="+ wp_db_user +" --dbpass="+ wp_db_pass +" --dbhost="+ wp_db_host +" --extra-php='define(\"WP_DEBUG\",true);\ndefine(\"WP_CONTENT_DIR\", dirname(__FILE__). \"/wp-content\" );\ndefine(\"WP_CONTENT_URL\",\"http://\". $_SERVER[\"HTTP_HOST\"]. \"/"+ wp_folder +"/wp-content\");'",
+                    "wp core config --path=wordpress --dbname="+ wp_db_name +" --dbuser="+ wp_db_user +" --dbpass="+ wp_db_pass +" --dbhost="+ wp_db_host +" --extra-php='define(\"WP_DEBUG\",true);\ndefine(\"WP_CONTENT_DIR\", dirname(__FILE__). \"/wp-content\" );\ndefine(\"WP_CONTENT_URL\",\"http://\". $_SERVER[\"HTTP_HOST\"]. \"/"+ wp_folder +"/wp-content\");'",
                     // Move wp-config to parent dir
                     'mv wordpress/wp-config.php wp-config.php',
                     // Create Database tables


### PR DESCRIPTION
I encountered a problem when running `grunt setup` where WP CLI was trying to generate a wp-config file in the root of the project, but the WordPress core files were in the folder `wordpress` and so WP CLI was unable to generate the wp-config file. 

With this fix, I added a parameter to tell WP CLI where the wordpress files are located. 